### PR TITLE
Add review notes for fleet_vehicle_reservation module

### DIFF
--- a/docs/fleet_vehicle_reservation_review.md
+++ b/docs/fleet_vehicle_reservation_review.md
@@ -1,0 +1,52 @@
+# Revisão do módulo `fleet_vehicle_reservation`
+
+## Estrutura do módulo
+A estrutura proposta está alinhada com o padrão esperado para módulos Odoo:
+
+- `__init__.py` e `__manifest__.py` na raiz do módulo.
+- Pastas `models/`, `views/`, `security/` e `data/`.
+- Arquivo `ir.model.access.csv` para permissões.
+- XMLs de views e menus.
+
+Sugestões opcionais (boas práticas):
+
+- `static/description/` com ícone e descrição do módulo.
+- `security/security.xml` se precisar de grupos/registros adicionais.
+
+## Pontos de atenção nos XMLs
+
+### Sequência (`data/sequence.xml`)
+No Odoo, os campos de um `record` precisam ser declarados com `<field name="...">`. O exemplo correto é:
+
+```xml
+<odoo>
+  <data noupdate="1">
+    <record id="seq_fleet_vehicle_reservation" model="ir.sequence">
+      <field name="name">Sequência de Reserva de Veículo</field>
+      <field name="code">fleet.vehicle.reservation</field>
+      <field name="prefix">RES/</field>
+      <field name="padding">5</field>
+      <field name="company_id" eval="False"/>
+    </record>
+  </data>
+</odoo>
+```
+
+### Menus e ações (`views/fleet_reservation_menu.xml`)
+A definição de `ir.actions.act_window` e de `menuitem` está adequada. Apenas confirme se o `parent="fleet.menu_root"` existe na versão do Odoo que você usa.
+
+### Views (`views/fleet_reservation_views.xml`)
+As views estão estruturadas de forma consistente para lista e formulário. A presença do chatter implica dependência do módulo `mail` no manifesto.
+
+## Manifesto (`__manifest__.py`)
+Garanta que:
+
+- `depends` inclua `fleet` (e `mail` se usar chatter).
+- `data` carregue os XMLs na ordem apropriada, por exemplo:
+  1. `security/ir.model.access.csv`
+  2. `data/sequence.xml`
+  3. `views/fleet_reservation_views.xml`
+  4. `views/fleet_reservation_menu.xml`
+
+## Conclusão
+A estrutura está correta; os principais ajustes são garantir o uso de `<field>` nos `record` do XML e declarar as dependências no manifesto.


### PR DESCRIPTION
### Motivation
- Add a concise review document describing the expected module layout and common XML/manifest issues to help validate and harden the `fleet_vehicle_reservation` module.

### Description
- Add `docs/fleet_vehicle_reservation_review.md` containing guidance on module structure, corrected XML `record` field usage, menu/action/view checks, and recommended `__manifest__.py` dependencies and data load order.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69835854e1e88321b788c21dccd55edf)